### PR TITLE
Clap.rs Migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,10 +9,10 @@ body:
   - type: checkboxes
     id: support_check
     attributes:
-      label: OD Support
+      label: Is OD Support
       description: Is the OD part of the currently supported list?
       options:
-        - label: OD
+        - label: Is supported
           required: true
   - type: input
     id: summary
@@ -31,8 +31,9 @@ body:
   - type: textarea
     id: sources
     attributes:
-      label: Screenshots/Links
-      description: If applicable, add screenshots and/or a link to help explain your problem.'
+      label: References
+      description: If applicable, add references (such as screenshots, links) to help
+      explain your problem.
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an idea for this project
 title: "New Feature"
-labels: ["enhancement"]
+labels: [ "enhancement" ]
 body:
   - type: input
     id: summary
@@ -10,24 +10,25 @@ body:
       description: Provide a clear and concise description of the issue.
     validations:
       required: true
-- type: textarea
-  id: details
-  attributes:
-    label: Details
-    description: Provide a detailed description of the issue as well as how to reproduce it.
-  validations:
-    required: true
-- type: textarea
-  id: sources
-  attributes:
-    label: Screenshots/Links
-    description: If applicable, add screenshots and/or a link to help explain your problem.'
-  validations:
-    required: false
-- type: textarea
-  id: comments
-  attributes:
-    label: Comments
-    description: Any other information you would like to add?
-  validations:
-    required: false
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Provide a detailed description of the issue as well as how to reproduce it.
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: References
+      description: If applicable, add references (such as screenshots, links) to help explain your
+      problem.
+    validations:
+      required: false
+  - type: textarea
+    id: comments
+    attributes:
+      label: Comments
+      description: Any other information you would like to add?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new-od-template.yml
+++ b/.github/ISSUE_TEMPLATE/new-od-template.yml
@@ -1,7 +1,7 @@
 name: New OD request
 description: Suggest support for a new Open Directory
 title: "New OD"
-labels: ["new od"]
+labels: [ "new od" ]
 assignees:
   - ZimCodes
 body:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "cmd_opts"
-version = "0.8.3"
+version = "0.8.5"
 dependencies = [
  "structopt",
 ]
@@ -1626,8 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "zeiver"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
+ "base64",
  "cmd_opts",
  "crawler",
  "logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "asset"
 version = "0.4.2"
 dependencies = [
@@ -102,24 +93,48 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "69c5a7f9997be616e47f0577ee38c91decb33392c5be4866494f34cdf329a9aa"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
 name = "cmd_opts"
 version = "0.8.5"
 dependencies = [
- "structopt",
+ "clap",
 ]
 
 [[package]]
@@ -345,12 +360,9 @@ checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -681,6 +693,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "parking_lot"
@@ -1175,33 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1240,13 +1234,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "time"
@@ -1381,18 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,12 +1409,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1553,6 +1535,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeiver"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["ZimCodes <23222943+ZimCodes@users.noreply.github.com>"]
 edition = "2021"
 description = "Web crawler designed to scrape, record, download, & scan content from ODs"
@@ -28,5 +28,6 @@ members = [
 crawler = {path = "./crawler"}
 cmd_opts = {path = "./cmd_opts"}
 logger = {path = "./logger"}
-reqwest = "0.11.4"
+reqwest = "~0.11.4"
 tokio = { version = "1.10.1", features = ["time","rt","macros","rt-multi-thread"] }
+base64 = "~0.13.0"

--- a/README.md
+++ b/README.md
@@ -279,10 +279,10 @@ Restrict Zeiver to send all requests through HTTPS connections only.
 
 ***-H, --headers***
 
-Sets the default headers to use for every request. *_Must use the __'header$value'__ format. Each header must also be
-**separated by a comma**._ 
+Sets the default headers to use for every request. *_Must use the __'header$value'__ format. 
+**Can be used multiple times!**
 
-Ex: `zeiver -H content-length$128,"accept$ text/html, application/xhtml+xml, image/webp"`
+Ex: `zeiver -H "accept$ text/html, application/xhtml+xml, image/webp" -H "content-length$128"`
 
 ***--auth***
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To **install/update** Zeiver follow these steps:
 The following code downloads files from _example.com/xms/imgs_, saves them in a local directory called _Cool_Content_,
 & sends a request with the ACCEPT-LANGUAGE header.
 
-`zeiver -h "accept-language$fr-CH, en;q=0.8, de;q=0.7" -o "./Cool_Content" example.com/xms/imgs`
+`zeiver -H "accept-language$fr-CH, en;q=0.8, de;q=0.7" -o "./Cool_Content" https://example.com/xms/imgs`
 
 ## Commands 
 ### Positional
@@ -283,6 +283,15 @@ Sets the default headers to use for every request. *_Must use the __'header$valu
 **separated by a comma**._ 
 
 Ex: `zeiver -H content-length$128,"accept$ text/html, application/xhtml+xml, image/webp"`
+
+***--auth***
+
+The Basic Authentication to use.
+
+The basic authentication needed to use a _closed_ directory. This is a shortcut for using the
+`Authorization: Basic` header. _Must use the_ `username:password` _format._
+
+Ex: `zeiver --auth "demo:say it"`
 
 ***-u***
 

--- a/cmd_opts/Cargo.toml
+++ b/cmd_opts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmd_opts"
-version = "0.8.3"
+version = "0.8.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cmd_opts/Cargo.toml
+++ b/cmd_opts/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "~0.3.22"
+clap = {version = "~3.2.10", features = ["derive"]}

--- a/cmd_opts/src/lib.rs
+++ b/cmd_opts/src/lib.rs
@@ -5,7 +5,8 @@ use std::path::PathBuf;
 #[derive(Parser, Debug, Clone)]
 #[clap(
     name = "Zeiver",
-    about = "Scrape, record, download & scout content from ODs."
+    about = "Scrape, record, download & scout content from ODs.",
+    version
 )]
 #[clap(bin_name = "zeiver")]
 pub struct Opts {

--- a/cmd_opts/src/lib.rs
+++ b/cmd_opts/src/lib.rs
@@ -1,63 +1,70 @@
+use clap::ArgAction;
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug, Clone)]
-#[structopt(
+#[derive(Parser, Debug, Clone)]
+#[clap(
     name = "Zeiver",
     about = "Scrape, record, download & scout content from ODs."
 )]
+#[clap(bin_name = "zeiver")]
 pub struct Opts {
     ///Update Zeiver to latest version.
-    #[structopt(short = "U",long,conflicts_with_all(&["record-only", "record", "cuts", "no-dirs", "output", "no-stats",
+    #[clap(short = 'U',long,conflicts_with_all(&["record-only", "record", "cut-dirs", "no-dirs",
+    "output", "no-stats",
     "depth", "timeout", "wait", "retry-wait", "random-wait", "tries", "redirects", "accept", "reject",
-    "u", "headers", "proxy", "proxy-auth", "input-file", "urls", "test", "scan", "print-header", "print-headers",
-    "all-certs", "https-only","verbose","download-only","output","output-record","input-record"]))]
+    "user-agent", "headers", "proxy", "proxy-auth", "input-file", "URLS", "test", "scan",
+    "print-header",
+    "print-headers",
+    "all-certs", "https-only","verbose","download-only","output","output-record","input-record"])
+    ,value_parser)]
     pub update: bool,
     ///Enable verbose output
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     pub verbose: bool,
     /// Run a quick scrape test
     ///
     /// Use the Scraper without activating the Recorder and Downloader.
-    #[structopt(long, conflicts_with_all(&["record-only", "record", "cuts", "no-dirs", "output", "output-record",
-    "no-stats", "input-record"]))]
+    #[clap(long, conflicts_with_all(&["record-only", "record", "cut-dirs", "no-dirs", "output",
+    "output-record",
+    "no-stats", "input-record"]),value_parser)]
     pub test: bool,
     /// Scan ODs
     ///
     /// Scan ODs displaying their content to the terminal. *A shortcut to activating*
     /// `--verbose` *&* `--test`.
-    #[structopt(long,conflicts_with_all(&["test","verbose","record-only","download-only"]))]
+    #[clap(long,conflicts_with_all(&["test","verbose","record-only","download-only"]),value_parser)]
     pub scan: bool,
     ///Prints all Response Headers to terminal
     ///
     ///Prints all available Response headers received from each url to the terminal. **This option
     /// takes precedence over all other options**
-    #[structopt(long, conflicts_with = "print-header")]
+    #[clap(long, conflicts_with = "print-header", value_parser)]
     pub print_headers: bool,
     ///Prints a Response Header to terminal
     ///
     /// Prints a specified Response Header to the terminal for each url. **This option takes
     /// precedence over all
     /// other options**.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub print_header: Option<String>,
     /// Prints the HTML Document to the terminal
     ///
     /// Prints the HTML Document of each URL to the terminal for viewing. Allows you to see in
     /// the eyes of Zeiver. **This option takes precedence over all other options**.
-    #[structopt(long, conflicts_with_all(&["print-header", "print-headers"]))]
+    #[clap(long, conflicts_with_all(&["print-header", "print-headers"]),value_parser)]
     pub print_pages: bool,
     /// Specify the maximum depth for recursive scraping
     ///
     /// This option is used to determine how far to look into a directory(ies) to retrieve files.
-    #[structopt(short = "d", long, default_value = "20")]
+    #[clap(short = 'd', long, default_value_t = 20, value_parser)]
     pub depth: usize,
     /// Do not create directories from URL (download)
     ///
     /// Do not create a hierarchy of directories structured the same as the URL
     /// the file came from. All files will be saved to the current output directory instead.
     /// *Only available when downloading.
-    #[structopt(long, parse(from_flag = std::ops::Not::not))]
+    #[clap(long, parse(from_flag = std::ops::Not::not))]
     pub no_dirs: bool,
     /// Ignores a set of remote directories from being created
     ///
@@ -67,136 +74,136 @@ pub struct Opts {
     /// URL: www.example.org/pub/xempcs/other/pics
     /// Original Save: ./pub/xempcs/other/pics
     /// After 2 cuts: ./other/pics
-    #[structopt(short, long = "cuts", default_value = "0")]
+    #[clap(short, long = "cuts", default_value_t = 0, value_parser)]
     pub cut_dirs: u32,
     /// Enables a request timeout (in secs)
     ///
     /// Adds a request timeout (in seconds). The timeout is applied from the time the request starts
     /// connecting until the response body has finished. '0' seconds means the connection will
     /// never timeout.
-    #[structopt(short = "T", long, default_value = "40")]
+    #[clap(short = 'T', long, default_value_t = 40, value_parser)]
     pub timeout: u64,
     /// Wait between each HTTP request for scraping
     ///
     /// Wait a specified number of seconds before sending each scraping request.
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     pub wait: Option<f32>,
     /// Wait between each HTTP request for download
     ///
     /// Wait a specified number of seconds before sending each download request.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub wait_download: Option<f32>,
     /// Use Downloader only
     ///
     /// Use only the Downloader to download all resources from links provided by an input file or
     /// command line.
-    #[structopt(long,conflicts_with_all(&["output-record","record","record-only"]))]
+    #[clap(long,conflicts_with_all(&["output-record","record","record-only"]),value_parser)]
     pub download_only: bool,
     /// Save the links only
     ///
     /// After scraping, instead of downloading the files, save the links to them.
     /// *The downloader will be disabled when this option is active. Enables
     /// Recorder instead.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub record_only: bool,
     /// Activates the Recorder
     ///
     /// Enables the Recorder which saves the scraped links to a file. Disabled by default.
     /// *Option cannot be used with `--record-only`.
-    #[structopt(long, conflicts_with = "record-only")]
+    #[clap(long, conflicts_with = "record-only", value_parser)]
     pub record: bool,
     /// Prevents Recorder from creating stat files
     ///
     /// The Recorder will no longer create stat files when saving scraped
     /// links to a file.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub no_stats: bool,
     /// Prevent Recorder from writing file names to stat files
     ///
     /// Stat files includes the names of all files in alphabetical order
     /// alongside the number of file extensions. This option prevents the Recorder from adding file names
     /// to stat files.
-    #[structopt(long, conflicts_with = "no-stats")]
+    #[clap(long, conflicts_with = "no-stats", value_parser)]
     pub no_stats_list: bool,
     /// The wait between each failed request (secs)
     ///
     /// Whenever a request fails, Zeiver will wait the specified
     /// number of seconds before retrying again
-    #[structopt(long, default_value = "8")]
+    #[clap(long, default_value_t = 8.0, value_parser)]
     pub retry_wait: f32,
     /// Wait a random amount of seconds before each HTTP request for scraping
     ///
     /// Randomly waits a specified number of seconds before each scraping
     /// requests. The time between requests will vary between
     /// 0.5 * [--wait,-w](inclusive) to 1.5 * [--wait,-w](exclusive)
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub random_wait: bool,
     /// Wait a random amount of seconds before each HTTP request for download
     ///
     /// Randomly waits a specified number of seconds before each
     /// download request. The time between requests will vary between
     /// 0.5 * [--wait-download](inclusive) to 1.5 * [--wait-download](exclusive)
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub random_download: bool,
     /// The amount of times to retry a failed connection/request
-    #[structopt(short, long, default_value = "20")]
+    #[clap(short, long, default_value_t = 20, value_parser)]
     pub tries: u32,
     /// Maximum redirects to follow
-    #[structopt(short, long, default_value = "10")]
+    #[clap(short, long, default_value_t = 10, value_parser)]
     pub redirects: usize,
     /// Files to accept for scraping, downloading, & recording (Regex)
     ///
     /// Using Regex, specify which files to accept for downloading & recording.
     /// Only the files that matches the regex will be acceptable
     /// for scraping, downloading, & recording. (This option takes precedence over --reject, -R)
-    #[structopt(short = "A", long)]
+    #[clap(short = 'A', long, value_parser)]
     pub accept: Option<String>,
     /// Files to reject for scraping, downloading, & recording (Regex)
     ///
     /// Using Regex, specify which files to reject for scraping, downloading, & recording.
     /// Only the files that match the regex will be rejected
     /// for scraping, downloading, & recording. (--accept, -A takes precedence over this option)
-    #[structopt(short = "R", long, conflicts_with = "accept")]
+    #[clap(short = 'R', long, conflicts_with = "accept", value_parser)]
     pub reject: Option<String>,
     /// The User Agent header to use
-    #[structopt(short)]
+    #[clap(short, value_parser)]
     pub user_agent: Option<String>,
     /// Basic Authentication to use. 'username:password' format
     ///
     /// The basic authentication needed to use a (closed) directory. Must use the
     /// 'username:password' format.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub auth: Option<String>,
     /// Use HTTPS only
     ///
     /// Restrict Zeiver to send all requests through HTTPS connections only.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub https_only: bool,
     /// Sets the default headers 'header:value'
     ///
     /// Sets the default headers for every request. Must use the
     /// 'header$value' format. Each header must also be separated by a comma.
     /// Ex: -H content-length$128,"accept$ text/html, application/xhtml+xml, image/webp"
-    #[structopt(short = "H", long, use_delimiter(true))]
+    #[clap(short = 'H', long, action(ArgAction::Append), value_parser)]
     pub headers: Option<Vec<String>>,
     /// The proxy to use
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub proxy: Option<String>,
     /// Authentication for the proxy 'username:password'
     ///
     /// The basic authentication needed to use the proxy. Must use the
     /// 'username:password' format.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub proxy_auth: Option<String>,
     /// Accept all certificates *(Beware!)*
     ///
     /// Accept all certificates even invalid ones. **Use this option at your own risk!**
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pub all_certs: bool,
     /// Read URLs from a local or external file
     ///
     /// Read URLs from a file to be sent to the Scraper. *Each line represents a URL to an OD.
-    #[structopt(short, long, requires_ifs(&[("None", "urls"), ("None", "input-record")]))]
+    #[clap(short, long, requires_ifs(&[("None", "URLS"), ("None", "input-record")]),value_parser)]
     pub input_file: Option<PathBuf>,
     /// Read URLs from a file containing file paths and create a stats file.
     ///
@@ -206,31 +213,34 @@ pub struct Opts {
     /// *Recorder* module.
     /// *Each line represents a URL to a file. **Activates Recorder**. Valid with `--verbose`,
     ///`--output`, `--output-record`, `--no-stats-list`
-    #[structopt(long, conflicts_with_all(&["record-only", "record", "cuts", "no-dirs", "output", "no-stats",
+    #[clap(long, conflicts_with_all(&["record-only", "record", "cut-dirs", "no-dirs", "output",
+    "no-stats",
     "depth", "timeout", "wait", "retry-wait", "random-wait", "tries", "redirects", "accept", "reject",
-    "U", "u", "headers", "proxy", "proxy-auth", "input-file", "urls", "test", "scan", "print-header", "print-headers",
-    "all-certs", "https-only"]))]
+    "update", "user-agent", "headers", "proxy", "proxy-auth", "input-file", "URLS", "test", "scan",
+    "print-header", "print-headers",
+    "all-certs", "https-only"]),value_parser)]
     pub input_record: Option<PathBuf>,
     /// Save Directory
     ///
     /// The local directory path to save files. Files saved by the *Recorder* are also stored here.
     /// Ex: ./downloads/images/dir
-    #[structopt(short, long, default_value = "./")]
+    #[clap(short, long, default_value = "./",value_parser = clap::value_parser!
+    (PathBuf))]
     pub output: PathBuf,
     /// Name of record file
     ///
     /// The name of the file to record the links received by the Recorder
     /// Ex: Link_file.txt
-    #[structopt(long, default_value = "URL_Records.txt")]
+    #[clap(long, default_value_t = String::from("URL_Records.txt"),value_parser)]
     pub output_record: String,
     /// The URLs to download content from
-    #[structopt(name = "URLS", requires_ifs(& [("None", "input-file"), ("None", "input-record")]))]
+    #[clap(value_parser, name = "URLS", requires_ifs(& [("None", "input-file"), ("None", "input-record")]))]
     pub urls: Vec<PathBuf>,
 }
 
 impl Opts {
     pub fn new() -> Opts {
-        let mut opts = Opts::from_args();
+        let mut opts = Opts::parse();
         if opts.scan {
             opts.verbose = true;
             opts.test = true;

--- a/cmd_opts/src/lib.rs
+++ b/cmd_opts/src/lib.rs
@@ -161,6 +161,12 @@ pub struct Opts {
     /// The User Agent header to use
     #[structopt(short)]
     pub user_agent: Option<String>,
+    /// Basic Authentication to use. 'username:password' format
+    ///
+    /// The basic authentication needed to use a (closed) directory. Must use the
+    /// 'username:password' format.
+    #[structopt(long)]
+    pub auth: Option<String>,
     /// Use HTTPS only
     ///
     /// Restrict Zeiver to send all requests through HTTPS connections only.


### PR DESCRIPTION
## Summary
### Migration
> As clap v3 is now out, and the structopt features are integrated into (almost as-is), structopt is now in maintenance mode: no new feature will be added. [Ref](https://docs.rs/structopt/latest/structopt/#maintenance)

Since there will be no new features added to the _structopt_ crate, it will be better to migrate completely to the _clap_ crate instead. 

### #4 
Issue #4 will also be addressed. This includes:
- Disallowing Zeiver automatically transforming header names/values to lowercase 
- Adding an `--auth` option for basic authentication

*Bug fixes will also be addressed in this pr.